### PR TITLE
Camera pose - do not reset if not needed.

### DIFF
--- a/src/robomeshcat/scene.py
+++ b/src/robomeshcat/scene.py
@@ -177,8 +177,6 @@ class Scene:
         self.camera_zoom = self._camera_zoom  # this will set the starting value of the property
         if self._camera_pose_modified:
             self.camera_pose = self._camera_pose
-        else:
-            self.reset_camera()
 
     """=== Following functions handle the camera control ==="""
 


### PR DESCRIPTION
Do not reset the camera pose if it is not modified; it will keep the current camera pose during animation.